### PR TITLE
Fix: Correct dashboard navigation issue

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { DashboardComponent } from './components/dashboard/dashboard.component';
+import { LancamentosComponent } from './components/lancamentos/lancamentos.component';
+// Assuming other components will be added later
+// import { InvestimentosComponent } from './components/investimentos/investimentos.component';
+// import { GruposComponent } from './components/grupos/grupos.component';
+// import { HistoricoComponent } from './components/historico/historico.component';
+
+const routes: Routes = [
+  { path: '', redirectTo: 'dashboard', pathMatch: 'full' }, // Redirects empty path to dashboard
+  { path: 'dashboard', component: DashboardComponent },
+  { path: 'lancamentos', component: LancamentosComponent },
+  // Add other routes here as needed
+  // { path: 'investimentos', component: InvestimentosComponent },
+  // { path: 'grupos', component: GruposComponent },
+  // { path: 'historico', component: HistoricoComponent },
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes, { useHash: true })],
+  exports: [RouterModule]
+})
+export class AppRoutingModule { }


### PR DESCRIPTION
The application was incorrectly navigating to `/#/` when attempting to access the dashboard, which prevented the dashboard component from loading.

This commit addresses the issue by:
1. Creating `src/app/app-routing.module.ts` (as it was missing).
2. Configuring the Angular Router with `useHash: true`.
3. Defining a default route (`path: ''`) that redirects to a 'dashboard' path.
4. Defining a specific route for 'dashboard' (`path: 'dashboard'`) that loads the `DashboardComponent`.

This ensures that navigating to the application root (`https://gestao-finc-compartilhada.web.app/`) or attempting to return to the dashboard from other pages correctly loads the `DashboardComponent` via `https://gestao-finc-compartilhada.web.app/#/dashboard`.

I also attempted to inspect and correct `routerLink` directives in HTML templates, but I didn't find any `.html` files within the `src/app/` directory. I expect the changes to the routing module to be the primary solution to the reported problem.