### PR TITLE
Fix: Establish core Angular structure for routing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Meu App de Finanças</title>
+    <base href="/">
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Adicionada CDN do Chart.js -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: '<router-outlet></router-outlet>'
+})
+export class AppComponent {
+  title = 'gestao-finc-compartilhada';
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { DashboardComponent } from './components/dashboard/dashboard.component';
+import { LancamentosComponent } from './components/lancamentos/lancamentos.component';
+// Import other components/modules if known or leave placeholders
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    DashboardComponent,
+    LancamentosComponent
+    // Declare other components here
+  ],
+  imports: [
+    BrowserModule,
+    AppRoutingModule
+    // Import other modules here
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-dashboard',
+  template: '<p>Dashboard Component Works!</p>'
+})
+export class DashboardComponent {}

--- a/src/app/components/lancamentos/lancamentos.component.ts
+++ b/src/app/components/lancamentos/lancamentos.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-lancamentos',
+  template: '<p>Lancamentos Component Works!</p>'
+})
+export class LancamentosComponent {}


### PR DESCRIPTION
This commit addresses the persistent dashboard navigation issue by setting up a more complete and conventional Angular application structure. The problem was that navigating to the dashboard resulted in `/#/` without loading the component.

Changes include:

1.  **Created `src/app/app.component.ts`:** Ensured a root application component exists and contains the `<router-outlet></router-outlet>` directive, which is essential for rendering routed components.

2.  **Created and Configured `src/app/app.module.ts`:** Established the main application module (`AppModule`) with:
    - Imports for `BrowserModule` and `AppRoutingModule`.
    - Declarations for `AppComponent`, `DashboardComponent` (placeholder), and `LancamentosComponent` (placeholder).
    - `AppComponent` set as the bootstrap component.

3.  **Created Placeholder Components:**
    - `src/app/components/dashboard/dashboard.component.ts`
    - `src/app/components/lancamentos/lancamentos.component.ts` These were created to allow `AppModule` and `AppRoutingModule` to be correctly configured.

4.  **Updated `public/index.html`:** Added the `<base href="/">` tag within the `<head>` section to ensure correct base URL resolution for routing.

These changes collectively provide the necessary foundation for Angular's routing mechanism to operate as expected, including the default redirection to the dashboard. The previously created `src/app/app-routing.module.ts` (with `useHash: true` and default redirect to 'dashboard') relies on this foundational setup.