### PR TITLE
Fix: Correct dashboard navigation and disable hashbang URLs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -268,7 +268,7 @@
             <div class="container mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="flex items-center justify-between h-16">
                     <div class="flex items-center">
-                        <a href="#/" class="flex-shrink-0 flex items-center text-primary-DEFAULT dark:text-primary-light font-bold text-xl">
+                        <a href="/" class="flex-shrink-0 flex items-center text-primary-DEFAULT dark:text-primary-light font-bold text-xl">
                             <svg class="h-8 w-auto mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
@@ -298,7 +298,7 @@
             <div class="container mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="flex items-center justify-between h-20">
                     <!-- Logo e Nome do App -->
-                    <a href="#/" class="flex items-center text-primary-DEFAULT dark:text-primary-light font-bold text-2xl">
+                    <a href="/" class="flex items-center text-primary-DEFAULT dark:text-primary-light font-bold text-2xl">
                         <svg class="h-10 w-auto mr-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                            <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
@@ -308,7 +308,7 @@
 
                     <!-- Navegação Desktop -->
                     <div class="hidden md:flex items-center space-x-6">
-                        <a href="#/" class="nav-link text-gray-600 dark:text-gray-300 hover:text-primary-DEFAULT dark:hover:text-primary-light px-3 py-2 rounded-md text-base font-medium transition-colors">Dashboard</a>
+                        <a href="/" class="nav-link text-gray-600 dark:text-gray-300 hover:text-primary-DEFAULT dark:hover:text-primary-light px-3 py-2 rounded-md text-base font-medium transition-colors">Dashboard</a>
                         <a href="#/lancamentos" class="nav-link text-gray-600 dark:text-gray-300 hover:text-primary-DEFAULT dark:hover:text-primary-light px-3 py-2 rounded-md text-base font-medium transition-colors">Lançamentos</a>
                         <a href="#/investimentos" class="nav-link text-gray-600 dark:text-gray-300 hover:text-primary-DEFAULT dark:hover:text-primary-light px-3 py-2 rounded-md text-base font-medium transition-colors">Investimentos</a>
                         <a href="#/grupos" class="nav-link text-gray-600 dark:text-gray-300 hover:text-primary-DEFAULT dark:hover:text-primary-light px-3 py-2 rounded-md text-base font-medium transition-colors">Grupos</a>
@@ -365,7 +365,7 @@
             <!-- Menu Mobile -->
             <div id="mobile-menu" class="md:hidden hidden bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700">
                 <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-                    <a href="#/" class="mobile-nav-link block px-3 py-2 rounded-md text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-primary-DEFAULT dark:hover:text-primary-light">Dashboard</a>
+                    <a href="/" class="mobile-nav-link block px-3 py-2 rounded-md text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-primary-DEFAULT dark:hover:text-primary-light">Dashboard</a>
                     <a href="#/lancamentos" class="mobile-nav-link block px-3 py-2 rounded-md text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-primary-DEFAULT dark:hover:text-primary-light">Lançamentos</a>
                     <a href="#/investimentos" class="mobile-nav-link block px-3 py-2 rounded-md text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-primary-DEFAULT dark:hover:text-primary-light">Investimentos</a>
                     <a href="#/grupos" class="mobile-nav-link block px-3 py-2 rounded-md text-base font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-primary-DEFAULT dark:hover:text-primary-light">Grupos</a>
@@ -521,7 +521,7 @@
             <p class="text-lg text-gray-500 dark:text-gray-400 mb-8">
                 A página que você está procurando não existe ou foi movida.
             </p>
-            <a href="#/"
+            <a href="/"
                class="px-8 py-3 bg-primary-DEFAULT text-white text-lg font-semibold rounded-lg hover:bg-primary-hover transition-colors shadow-lg">
                 Voltar para o Início
             </a>

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -18,7 +18,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, { useHash: true })],
+  imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }


### PR DESCRIPTION
This commit addresses two main issues:
1. The dashboard button/link incorrectly navigated to `/#/` instead of the root URL, preventing the dashboard from loading correctly when you were already on a hash-based URL.
2. Your application used hashbang URLs (`/#/route`) for Angular routes.

Changes:

- **Modified `public/index.html`:** I updated several `href` attributes within `<template>` tags (for logo, dashboard links in different states, and 404 page) from `href="#/"` to `href="/"`. This ensures these primary navigation links force a reload to the application root (`https://gestao-finc-compartilhada.web.app/`), bypassing Angular's hash routing for these specific cases and correctly loading the dashboard.

- **Updated `src/app/app-routing.module.ts`:** I removed `{ useHash: true }` from the `RouterModule.forRoot()` configuration. This defaults Angular routing to `useHash: false`, meaning routes like `/lancamentos` will now be used instead of `/#/lancamentos`. This change promotes cleaner URLs and relies on the server (e.g., Firebase Hosting) being configured with rewrites for SPA behavior.

These changes provide a more consistent and user-friendly navigation experience.