### PR TITLE
Fix: Adjust dark theme for better contrast

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -90,7 +90,7 @@
                         Acesse sua conta
                     </h2>
                     <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                        Ou <button id="go-to-register" class="font-medium text-primary-DEFAULT hover:text-primary-hover">crie uma nova conta</button>
+                        Ou <button id="go-to-register" class="font-medium text-primary-DEFAULT hover:text-primary-hover dark:text-primary-light dark:hover:text-primary-DEFAULT">crie uma nova conta</button>
                     </p>
                 </div>
                 <form id="login-form" class="space-y-6">
@@ -106,7 +106,7 @@
                     </div>
                     <div class="flex items-center justify-between">
                         <div class="text-sm">
-                            <a href="#" id="forgot-password-link" class="font-medium text-primary-DEFAULT hover:text-primary-hover">Esqueceu sua senha?</a>
+                            <a href="#" id="forgot-password-link" class="font-medium text-primary-DEFAULT hover:text-primary-hover dark:text-primary-light dark:hover:text-primary-DEFAULT">Esqueceu sua senha?</a>
                         </div>
                     </div>
                     <div>
@@ -150,7 +150,7 @@
                         Crie sua conta
                     </h2>
                     <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                        Já tem uma conta? <button id="go-to-login" class="font-medium text-primary-DEFAULT hover:text-primary-hover">Faça login</button>
+                        Já tem uma conta? <button id="go-to-login" class="font-medium text-primary-DEFAULT hover:text-primary-hover dark:text-primary-light dark:hover:text-primary-DEFAULT">Faça login</button>
                     </p>
                 </div>
                 <form id="register-form" class="space-y-6">


### PR DESCRIPTION
Corrected text colors for certain links and buttons in the login and register pages to ensure better readability in dark mode. Specifically, applied `dark:text-primary-light` to elements that previously only had `text-primary-DEFAULT`, which could lack contrast against dark backgrounds.

Verified that other components, including modals, cards, and chart containers, generally have appropriate `dark:` prefixed Tailwind CSS classes for backgrounds and text.